### PR TITLE
Allow Client to take &str or String

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,4 +1,5 @@
-use  super::{Agent, Catalog, Health, Keystore, Session};
+use std::borrow::{Borrow, Cow};
+use super::{Agent, Catalog, Health, Keystore, Session};
 
 /// provides a client to the Consul API
 pub struct Client{
@@ -14,14 +15,16 @@ pub struct Client{
 
 impl Client {
     /// Constructs a consul client
-    pub fn new(address: &str) -> Client {
-        let agent = Agent::new(address);
-        let catalog = Catalog::new(address);
-        let health = Health::new(address);
-        let keystore = Keystore::new(address);
-        let session = Session::new(address);
+    pub fn new<'a, S>(address: S) -> Client where S: Into<Cow<'a, str>> {
+        let cow = address.into();
+        let addr = cow.borrow();
+        let agent = Agent::new(addr);
+        let catalog = Catalog::new(addr);
+        let health = Health::new(addr);
+        let keystore = Keystore::new(addr);
+        let session = Session::new(addr);
         Client {
-            agent:agent,
+            agent: agent,
             catalog: catalog,
             health: health,
             session: session,


### PR DESCRIPTION
It feels like a slightly nicer API to take both forms of strings, one
less thing to think about.