### PR TITLE
Modernize depency on reqwest and tls impl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ keywords = ["consul", "discovery"]
 
 
 [dependencies]
-error-chain = "0.10"
+error-chain = "^0.12"
 serde = "1"
 serde_derive = "1"
-reqwest = "0.6"
+reqwest = {version="^0.9", features=["default-tls"]}
 url = "1.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![allow(non_snake_case)]
-#![allow(unused_doc_comment)]
+#![allow(unused_doc_comments)]
 
 
 #[macro_use]
@@ -21,6 +21,7 @@ mod request;
 
 use std::time::Duration;
 
+use reqwest::ClientBuilder;
 use reqwest::Client as HttpClient;
 
 use errors::Result;
@@ -47,7 +48,8 @@ pub struct Config {
 
 impl Config {
     pub fn new() -> Result<Config> {
-        HttpClient::new()
+        ClientBuilder::new()
+            .build()
             .chain_err(|| "Failed to build reqwest client")
             .map(|client| {
                 Config {


### PR DESCRIPTION
This PR updates the dependencies to the latest reqwest and error_chain crates, both of which have undergone an API update in the last year. This results in significantly reduced build conflicts surrounding the use of native-tls, openssl, and openssl-sys and reduces the need to have multiple openssl implementations in parallel. 