### PR TITLE
Hyper to reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,5 @@ exclude = [
 serde = "1"
 serde_json = "1"
 serde_derive = "1"
-hyper = "0.10"
-hyper-openssl = "0.2"
-openssl = "0.9"
+reqwest = "0.9"
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,9 +34,7 @@
 extern crate serde_derive;
 extern crate serde;
 extern crate serde_json;
-extern crate hyper;
-extern crate openssl;
-extern crate hyper_openssl;
+extern crate reqwest;
 
 /// public api
 pub use agent::{Agent, AgentMember};

--- a/src/request.rs
+++ b/src/request.rs
@@ -4,8 +4,6 @@ use std::io::Read;
 use error::ConsulResult;
 use std::string::String;
 
-type Error = Box<dyn std::error::Error>;
-
 #[derive(Debug)]
 pub struct Handler {
     client: Client,

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,11 +1,10 @@
-use hyper::{Client, status};
-use hyper::net::HttpsConnector;
-use hyper::header::{Headers, ContentType};
-use hyper::mime::Mime;
-use hyper_openssl::OpensslClient;
+use reqwest::Client;
+use reqwest::header::CONTENT_TYPE;
 use std::io::Read;
-use openssl::ssl::*;
 use error::ConsulResult;
+use std::string::String;
+
+type Error = Box<dyn std::error::Error>;
 
 #[derive(Debug)]
 pub struct Handler {
@@ -15,150 +14,58 @@ pub struct Handler {
 
 impl Handler {
     pub fn new(url: &str) -> Handler {
-        let client;
-        if url.trim().starts_with("https") {
-            let mut ssl_connector_builder = SslConnectorBuilder::new(SslMethod::tls()).unwrap();
-            {
-                let mut ssl_context_builder = ssl_connector_builder.builder_mut();
-                ssl_context_builder.set_verify(SSL_VERIFY_NONE);
-            }
-            let ssl_connector = ssl_connector_builder.build();
-            let mut ssl = OpensslClient::from(ssl_connector);
-            ssl.danger_disable_hostname_verification(true);
-            let connector = HttpsConnector::new(ssl);
-            client = Client::with_connector(connector);
-        }
-        else {
-            client = Client::new();
-        }
-
         Handler {
-            client: client,
+            client: Client::new(),
             url: url.to_owned()
         }
     }
 
     pub fn get(&self, endpoint: &str) -> ConsulResult<String> {
         let full_url = format!("{}/{}", self.url.trim_right_matches('/'), endpoint);
-        let mut res = self.client.get(&full_url)
-            .send()
-            .map_err(|e| format!("{}", e))?;
-
-        if res.status == status::StatusCode::Ok {
-            let mut response = String::new();
-            res.read_to_string(&mut response)
-                .map_err(|e| format!("{}", e))?;
-            Ok(response)
-        }
-        else {
-            let mut response = String::new();
-            res.read_to_string(&mut response)
-                .map_err(|e| format!("{}", e))?;
-
-            if !response.is_empty() {
-                Ok(response)
-            }
-            else {
-                Err(format!("Request failed with status: {:?}", res.status_raw()))
-            }
-        }
+        self.client.get(&full_url).send()
+            .map_err(|e| e.to_string())?
+            .text()
+            .map_err(|e| e.to_string())
     }
 
     pub fn _post(&self, endpoint: &str, req: String) -> ConsulResult<String> {
         let full_url = format!("{}/{}", self.url.trim_right_matches('/'), endpoint);
-
-        let mut res = self.client.post(&full_url)
-            .body(&req)
+        self.client.post(&full_url)
+            .body(req)
             .send()
-            .map_err(|e| format!("{}", e))?;
-
-        if res.status == status::StatusCode::Ok {
-            let mut response = String::new();
-            res.read_to_string(&mut response)
-                .map_err(|e| format!("{}", e))?;
-            Ok(response)
-        }
-        else {
-            let mut response = String::new();
-            res.read_to_string(&mut response)
-                .map_err(|e| format!("{}", e))?;
-
-            if !response.is_empty() {
-                Ok(response)
-            }
-            else {
-                Err(format!("Request failed with status: {:?}", res.status_raw()))
-            }
-        }
+            .map_err(|e| e.to_string())?
+            .text()
+            .map_err(|e| e.to_string())
     }
 
     pub fn put(&self, endpoint: &str, req: String, content_type: Option<&str>) -> ConsulResult<String> {
         let full_url = format!("{}/{}", self.url.trim_right_matches('/'), endpoint);
-
-        let mut res;
         if let Some(content) = content_type {
-            let mime: Mime = content.parse().unwrap();
-            let mut headers = Headers::new();
-            headers.set(ContentType(mime));
-            res = self.client.put(&full_url)
-                .headers(headers)
-                .body(&req)
+            self.client.put(&full_url)
+                .body(req)
+                .header(CONTENT_TYPE, content)
                 .send()
-                .map_err(|e| format!("{}", e))?;
-
+                .map_err(|e| e.to_string())?
+                .text()
+                .map_err(|e| e.to_string())
         }
         else {
-            res = self.client.put(&full_url)
-                .body(&req)
+            self.client.put(&full_url)
+                .body(req)
                 .send()
-                .map_err(|e| format!("{}", e))?;
+                .map_err(|e| e.to_string())?
+                .text()
+                .map_err(|e| e.to_string())
         }
-
-        if res.status == status::StatusCode::Ok {
-            let mut response = String::new();
-            res.read_to_string(&mut response)
-                .map_err(|e| format!("{}", e))?;
-            Ok(response)
-        }
-        else {
-            let mut response = String::new();
-            res.read_to_string(&mut response)
-                .map_err(|e| format!("{}", e))?;
-
-            if !response.is_empty() {
-                Ok(response)
-            }
-            else {
-                Err(format!("Request failed with status: {:?}", res.status_raw()))
-            }
-        }
-
     }
 
     pub fn delete(&self, endpoint: &str) -> ConsulResult<String> {
         let full_url = format!("{}/{}", self.url.trim_right_matches('/'), endpoint);
-        let mut res = self.client.delete(&full_url)
+        self.client.delete(&full_url)
             .send()
-            .map_err(|e| format!("{}", e))?;
-
-        if res.status == status::StatusCode::Ok {
-            let mut response = String::new();
-            res.read_to_string(&mut response)
-                .map_err(|e| format!("{}", e))?;
-            Ok(response)
-        }
-        else {
-            let mut response = String::new();
-            res.read_to_string(&mut response)
-                .map_err(|e| format!("{}", e))?;
-
-            if !response.is_empty() {
-                Ok(response)
-            }
-            else {
-                Err(format!("Request failed with status: {:?}", res.status_raw()))
-            }
-        }
+            .map_err(|e| e.to_string())?
+            .text()
+            .map_err(|e| e.to_string())
     }
 
 


### PR DESCRIPTION
### Problem
The version of hyper and openssl that this project uses are outdated and don't work with newer openssl and libressl.
```
openssl-sys v0.9.23 ...
This crate is only compatible with OpenSSL 1.0.1, 1.0.2, and 1.1.0, or LibreSSL
2.5 and 2.6.0, but a different version of OpenSSL was found. The build is now
aborting due to this version mismatch.
```

### Solution
One solution was to update the `hyper` and `openssl` versions, but `hyper`'s API has changed significantly and gotten much more complicated. Instead, I opted to replace `hyper` with the `reqwest` library. `reqwest` is a convenience wrapper around `hyper`, and is even recommended by the `hyper` project. From https://github.com/hyperium/hyper:
```
Hyper is a relatively low-level library, if you are looking for simple high-level HTTP
client, then you may wish to consider reqwest, which is built on top of this library.
```
This library only does simple synchronous HTTP calls, and `reqwest` is totally sufficient for these purposes.