### PR TITLE
Updated crate version to 0.2.0 in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,5 +31,5 @@ Simply include consul-rust in your Cargo dependencies.
 
 ```toml
 [dependencies]
-consul = "0.1"
+consul = "0.2.0"
 ```


### PR DESCRIPTION
Updated version in README to match the current version from crates.io