### PR TITLE
[BUGFIX] Fix incorrect return values for services() in catalog

### DIFF
--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -90,7 +90,7 @@ pub trait Catalog {
     ) -> Result<((), WriteMeta)>;
     fn datacenters(&self) -> Result<(Vec<String>, QueryMeta)>;
     fn nodes(&self, q: Option<&QueryOptions>) -> Result<(Vec<Node>, QueryMeta)>;
-    fn services(&self, q: Option<&QueryOptions>) -> Result<(HashMap<String, String>, QueryMeta)>;
+    fn services(&self, q: Option<&QueryOptions>) -> Result<(HashMap<String, Vec<String>>, QueryMeta)>;
 }
 
 impl Catalog for Client {
@@ -139,7 +139,7 @@ impl Catalog for Client {
         get("/v1/catalog/nodes", &self.config, HashMap::new(), q)
     }
 
-    fn services(&self, q: Option<&QueryOptions>) -> Result<(HashMap<String, String>, QueryMeta)> {
+    fn services(&self, q: Option<&QueryOptions>) -> Result<(HashMap<String, Vec<String>>, QueryMeta)> {
         get("/v1/catalog/services", &self.config, HashMap::new(), q)
     }
 }

--- a/tests/catalog.rs
+++ b/tests/catalog.rs
@@ -1,5 +1,4 @@
 extern crate consul;
-use consul::catalog::Catalog;
 use consul::{Client, Config};
 
 #[test]
@@ -9,4 +8,17 @@ fn ds_test() {
     let client = Client::new(config);
     let r = client.datacenters().unwrap();
     assert_eq!(r.0, ["dc1"]);
+}
+
+#[test]
+fn ds_services_test() {
+    use consul::catalog::Catalog;
+    let config = Config::new().unwrap();
+    let client = Client::new(config);
+    let r = client.services(Option::None).unwrap();
+    assert_ne!(r.0.len(), 0);
+    match r.0.get("consul") {
+        None      => panic!("Should have a Consul service"),
+        Some(val) => assert_eq!(val.len(), 0) // consul has no tags
+    }
 }


### PR DESCRIPTION
Type was incorrect, avoid crashing when calling services()