### PR TITLE
[No Feature]: Reformat all code using cargo fmt

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,9 +1,8 @@
 use std::collections::HashMap;
 
-
-use crate::Client;
 use crate::errors::Result;
 use crate::request::{get, put};
+use crate::Client;
 
 #[serde(default)]
 #[derive(Clone, Default, Eq, PartialEq, Serialize, Deserialize, Debug)]

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -90,7 +90,10 @@ pub trait Catalog {
     ) -> Result<((), WriteMeta)>;
     fn datacenters(&self) -> Result<(Vec<String>, QueryMeta)>;
     fn nodes(&self, q: Option<&QueryOptions>) -> Result<(Vec<Node>, QueryMeta)>;
-    fn services(&self, q: Option<&QueryOptions>) -> Result<(HashMap<String, Vec<String>>, QueryMeta)>;
+    fn services(
+        &self,
+        q: Option<&QueryOptions>,
+    ) -> Result<(HashMap<String, Vec<String>>, QueryMeta)>;
 }
 
 impl Catalog for Client {
@@ -139,7 +142,10 @@ impl Catalog for Client {
         get("/v1/catalog/nodes", &self.config, HashMap::new(), q)
     }
 
-    fn services(&self, q: Option<&QueryOptions>) -> Result<(HashMap<String, Vec<String>>, QueryMeta)> {
+    fn services(
+        &self,
+        q: Option<&QueryOptions>,
+    ) -> Result<(HashMap<String, Vec<String>>, QueryMeta)> {
         get("/v1/catalog/services", &self.config, HashMap::new(), q)
     }
 }

--- a/src/connect_ca.rs
+++ b/src/connect_ca.rs
@@ -2,9 +2,9 @@ use std::collections::HashMap;
 
 use serde_json::Value;
 
-use crate::{Client, QueryMeta, QueryOptions, WriteMeta, WriteOptions};
 use crate::errors::Result;
 use crate::request::{get, put};
+use crate::{Client, QueryMeta, QueryOptions, WriteMeta, WriteOptions};
 
 #[serde(default)]
 #[derive(Default, Serialize, Deserialize, Debug)]

--- a/src/health.rs
+++ b/src/health.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 
-use crate::{Client, QueryMeta, QueryOptions};
 use crate::agent::AgentService;
 use crate::errors::Result;
 use crate::request::get;
+use crate::{Client, QueryMeta, QueryOptions};
 
 #[serde(default)]
 #[derive(Eq, Default, PartialEq, Serialize, Deserialize, Debug)]

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -19,7 +19,7 @@ pub struct KVPair {
 
 pub trait KV {
     fn acquire(&self, _: &KVPair, _: Option<&WriteOptions>) -> Result<(bool, WriteMeta)>;
-    fn delete(&self, _ : &str, _: Option<&WriteOptions>) -> Result<(bool, WriteMeta)>;
+    fn delete(&self, _: &str, _: Option<&WriteOptions>) -> Result<(bool, WriteMeta)>;
     fn get(&self, _: &str, _: Option<&QueryOptions>) -> Result<(Option<KVPair>, QueryMeta)>;
     fn list(&self, _: &str, _: Option<&QueryOptions>) -> Result<(Vec<KVPair>, QueryMeta)>;
     fn put(&self, _: &KVPair, _: Option<&WriteOptions>) -> Result<(bool, WriteMeta)>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,6 @@ extern crate error_chain;
 #[macro_use]
 extern crate serde_derive;
 
-
 pub mod agent;
 pub mod catalog;
 pub mod connect_ca;
@@ -19,13 +18,10 @@ mod request;
 
 use std::time::Duration;
 
-
-use reqwest::ClientBuilder;
 use reqwest::Client as HttpClient;
+use reqwest::ClientBuilder;
 
 use errors::{Result, ResultExt};
-
-
 
 #[derive(Clone, Debug)]
 pub struct Client {
@@ -48,7 +44,7 @@ pub struct Config {
 
 impl Config {
     pub fn new() -> Result<Config> {
-       ClientBuilder::new()
+        ClientBuilder::new()
             .build()
             .chain_err(|| "Failed to build reqwest client")
             .map(|client| Config {

--- a/src/request.rs
+++ b/src/request.rs
@@ -12,8 +12,8 @@ use reqwest::StatusCode;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
-use crate::{Config, QueryMeta, QueryOptions, WriteMeta, WriteOptions};
 use crate::errors::{Result, ResultExt};
+use crate::{Config, QueryMeta, QueryOptions, WriteMeta, WriteOptions};
 
 pub fn get_vec<R: DeserializeOwned>(
     path: &str,

--- a/tests/catalog.rs
+++ b/tests/catalog.rs
@@ -18,7 +18,7 @@ fn ds_services_test() {
     let r = client.services(Option::None).unwrap();
     assert_ne!(r.0.len(), 0);
     match r.0.get("consul") {
-        None      => panic!("Should have a Consul service"),
-        Some(val) => assert_eq!(val.len(), 0) // consul has no tags
+        None => panic!("Should have a Consul service"),
+        Some(val) => assert_eq!(val.len(), 0), // consul has no tags
     }
 }


### PR DESCRIPTION
Reformat all code using `cargo fmt`.
Will add Travis tests to ensure all contributors share the same formatting rules